### PR TITLE
Feature/support base index

### DIFF
--- a/tmssh
+++ b/tmssh
@@ -8,7 +8,7 @@ set -e
 # THIS_FILE_NAME is supposed to be "tmssh".
 readonly THIS_FILE_NAME="${0##*/}"
 readonly ABS_THIS_FILE_NAME="$(cd $(dirname $0) && pwd)/$THIS_FILE_NAME"
-readonly TMUX_PANE_BASE_INDEX=$(tmux show-window-options -g | grep pane-base-index | perl -anle 'print $F[1]')
+readonly TMUX_PANE_BASE_INDEX=$(tmux show-window-options -g | grep '^pane-base-index' | head -n 1 | perl -anle 'print $F[1]')
 
 # This is supposed to be tmssh-12345(PID)
 readonly SESSION_NAME="$THIS_FILE_NAME-$$"

--- a/tmssh
+++ b/tmssh
@@ -8,6 +8,7 @@ set -e
 # THIS_FILE_NAME is supposed to be "tmssh".
 readonly THIS_FILE_NAME="${0##*/}"
 readonly ABS_THIS_FILE_NAME="$(cd $(dirname $0) && pwd)/$THIS_FILE_NAME"
+readonly TMUX_PANE_BASE_INDEX=$(tmux show-window-options -g | grep pane-base-index | perl -anle 'print $F[1]')
 
 # This is supposed to be tmssh-12345(PID)
 readonly SESSION_NAME="$THIS_FILE_NAME-$$"
@@ -42,7 +43,7 @@ function split_window()
     local _window_name=${_hosts[$_last_host_idx]}
 
     # ".0" means a pane which has the youngest number of index.
-    tmux select-pane -t ${_window_name}.0
+    tmux select-pane -t ${_window_name}.${TMUX_PANE_BASE_INDEX}
 
     for i in $(seq 1 $_last_host_idx)
     do
@@ -57,10 +58,10 @@ function split_window()
     done
 
     # Delete the first window
-    tmux kill-pane -t ${_window_name}.0
+    tmux kill-pane -t ${_window_name}.${TMUX_PANE_BASE_INDEX}
 
     # Select second window
-    tmux select-pane -t ${_window_name}.0
+    tmux select-pane -t ${_window_name}.${TMUX_PANE_BASE_INDEX}
 
     # Sending ssh opearations for each pane.
     for i in $(seq 0 $(($_last_host_idx-1)))

--- a/tmssh
+++ b/tmssh
@@ -8,7 +8,6 @@ set -e
 # THIS_FILE_NAME is supposed to be "tmssh".
 readonly THIS_FILE_NAME="${0##*/}"
 readonly ABS_THIS_FILE_NAME="$(cd $(dirname $0) && pwd)/$THIS_FILE_NAME"
-readonly TMUX_PANE_BASE_INDEX=$(tmux show-window-options -g | grep '^pane-base-index' | head -n 1 | perl -anle 'print $F[1]')
 
 # This is supposed to be tmssh-12345(PID)
 readonly SESSION_NAME="$THIS_FILE_NAME-$$"
@@ -38,12 +37,13 @@ function usage() {
 #
 function split_window()
 {
+    local _pane_base_index=$(tmux show-window-options -g | grep '^pane-base-index' | head -n 1 | perl -anle 'print $F[1]')
     local _hosts=($*)
     local _last_host_idx=$(($# - 1))
     local _window_name=${_hosts[$_last_host_idx]}
 
     # ".0" means a pane which has the youngest number of index.
-    tmux select-pane -t ${_window_name}.${TMUX_PANE_BASE_INDEX}
+    tmux select-pane -t ${_window_name}.${_pane_base_index}
 
     for i in $(seq 1 $_last_host_idx)
     do
@@ -58,15 +58,15 @@ function split_window()
     done
 
     # Delete the first window
-    tmux kill-pane -t ${_window_name}.${TMUX_PANE_BASE_INDEX}
+    tmux kill-pane -t ${_window_name}.${_pane_base_index}
 
     # Select second window
-    tmux select-pane -t ${_window_name}.${TMUX_PANE_BASE_INDEX}
+    tmux select-pane -t ${_window_name}.${_pane_base_index}
 
     # Sending ssh opearations for each pane.
     for i in $(seq 0 $(($_last_host_idx-1)))
     do
-        tmux send-keys -t $_window_name.$i "ssh ${_hosts[i]}" C-m
+        tmux send-keys -t $_window_name.$(($i + ${_pane_base_index})) "ssh ${_hosts[i]}" C-m
     done
 
     # Window is serarated vertically, when the number of panes is 1 or 2.


### PR DESCRIPTION
Supporting non 0-indexed pane.
Concretely, tmssh works even if your tmux has following setting.

```
set-window-option -g pane-base-index 1
```
